### PR TITLE
Add DNS Propagation Checker - open-source DNS propagation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,7 @@ maintained by a team of experts, with amazing capabilities
 
 * [NetworkWhois DNS Propagation](https://networkwhois.com/dns-propagation) - Check DNS propagation across multiple public resolvers and locations.
 
+* [DNS Propagation Checker](https://dns-propagation-checker.autocompany.workers.dev) - Open-source DNS propagation checker with 10+ global DNS servers, supports A/AAAA/CNAME/MX/NS/TXT records. ([GitHub](https://github.com/brancogao/dns-propagation-checker))
+
 ## Contributions welcome
 If you wish to contribute to this list, just fork, make your changes and send me a pull request, I'll be happy to review all of your suggestions :)


### PR DESCRIPTION
## Description
Added [DNS Propagation Checker](https://github.com/brancogao/dns-propagation-checker) - an open-source tool for checking DNS propagation across multiple global DNS servers.

## Features
- 10+ global DNS servers (Google, Cloudflare, Quad9, etc.)
- Supports A, AAAA, CNAME, MX, NS, TXT records
- Real-time propagation percentage visualization
- Free hosted version available
- Open-source (MIT license)

## Demo
https://dns-propagation-checker.autocompany.workers.dev

This complements the existing NetworkWhois entry with an open-source alternative that developers can self-host.