### PR TITLE
Add digga, an open-source domain research toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ maintained by a team of experts, with amazing capabilities
 
 * [DNS Propagation Checker](https://dns-propagation-checker.autocompany.workers.dev) - Open-source DNS propagation checker with 10+ global DNS servers, supports A/AAAA/CNAME/MX/NS/TXT records. ([GitHub](https://github.com/brancogao/dns-propagation-checker))
 
+* [digga](https://digga.dev) - Free and open-source domain and infrastructure research toolkit for DNS, RDAP, WHOIS, subdomain discovery, email authentication, and TLS certificate inspection. No signup required. ([GitHub](https://github.com/maaaathis/digga))
+
 * [IntoDNS.ai](https://intodns.ai) - AI-powered DNS & email security scanner. Checks SPF, DKIM, DMARC, DNSSEC, blacklists and provides actionable fixes. Free, no signup required.
 
 * [net-benchmark](https://github.com/net-benchmark/net-benchmark) - DNS/HTTP/SSL benchmarking CLI with DoH, DoT, DNSSEC validation and full timing breakdown.


### PR DESCRIPTION
## Add digga

[digga](https://digga.dev) is a free and open-source domain and infrastructure research toolkit.

It provides:

* DNS lookups across multiple DNS over HTTPS resolvers
* RDAP lookups with WHOIS fallback
* Passive subdomain discovery
* IP and ASN information
* SPF, DKIM, DMARC, MTA-STS, TLS-RPT, and BIMI checks
* TLS certificate inspection

digga is completely free, requires no account, and is available under the AGPL 3.0 license.

Source code: https://github.com/maaaathis/digga