### PR TITLE
Add Relaymetry (free SPF/DKIM/DMARC/MTA-STS checker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ maintained by a team of experts, with amazing capabilities
 
 * [IntoDNS.ai](https://intodns.ai) - AI-powered DNS & email security scanner. Checks SPF, DKIM, DMARC, DNSSEC, blacklists and provides actionable fixes. Free, no signup required.
 
+* [Relaymetry](https://relaymetry.com) - Free SPF, DKIM, DMARC and MTA-STS checker. Expands SPF includes to show the real DNS-lookup count and reports the specific fixes. No signup required.
+
 * [net-benchmark](https://github.com/net-benchmark/net-benchmark) - DNS/HTTP/SSL benchmarking CLI with DoH, DoT, DNSSEC validation and full timing breakdown.
 
 * [DomScan](https://domscan.net) - Domain intelligence with free DNS, WHOIS/RDAP, SSL and DNS propagation lookup tools, plus an API and MCP server for domain availability, valuation and brand protection.


### PR DESCRIPTION
Adds Relaymetry, a free SPF/DKIM/DMARC/MTA-STS checker, alongside the other email-authentication scanners already in the list (digga, IntoDNS.ai). It expands SPF includes to show the real DNS-lookup count against the 10-lookup limit and reports specific fixes. Free, no signup required.

Disclosure: I'm the founder of Relaymetry.