### PR TITLE
Add Zero Dollar Domains — live RDAP hunter + free-program catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A curated list of open source tools, and free services, related to Domain Name S
 [DNS Propagation Checker](https://github.com/rockswang/dns-propagation-checker) - Open-source DNS propagation checker with 10+ global DNS servers, supports A/AAAA/CNAME/MX/NS/TXT records. (GitHub)
 
 [digga](https://github.com/spatie/digga) - Free and open-source domain and infrastructure research toolkit for DNS, RDAP, WHOIS, subdomain discovery, email authentication, and TLS certificate inspection. No signup required. (GitHub)
+[Zero Dollar Domains](https://arynjennen1989-stack.github.io/) - Catalog of still-free domain/subdomain programs plus a live RDAP hunter for unused cheap TLD names. Honest about forever-free vs year-1 cheap. No expired-.com scrapes.
 
 [IntoDNS.ai](https://intodns.ai/) - AI-powered DNS & email security scanner. Checks SPF, DKIM, DMARC, DNSSEC, blacklists and provides actionable fixes. Free, no signup required.
 


### PR DESCRIPTION
Adds [Zero Dollar Domains](https://arynjennen1989-stack.github.io/), a small public tool that:

- asks official registries via RDAP whether a name is still unregistered on cheap TLDs
- checks DNS to see if a taken name is actually dead (no NS)
- lists programs that still give a $0 domain or subdomain (eu.org, is-a.dev, etc.)

Placed next to digga because both are no-signup domain research tools. I maintain the site. Happy to reword or move the entry.