### PR TITLE
Add Nutilz SPF Record Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ A curated list of open source tools, and free services, related to Domain Name S
 
 [Nutilz DMARC Record Generator](https://nutilz.com/dmarc-record-generator) - Free DMARC record builder and validator. Generate TXT records with policy (none/quarantine/reject), subdomain policy, rollout percentage, aggregate/forensic report addresses, and SPF/DKIM alignment mode. Also parses and validates existing records. No signup required.
 
+[Nutilz SPF Record Generator](https://nutilz.com/spf-record-generator) - Free SPF record builder and validator. Counts DNS lookups against the RFC 7208 10-lookup limit, configures mechanisms (include, ip4, ip6, a, mx), adds email provider presets (Google Workspace, Microsoft 365, SendGrid, Mailchimp), and sets enforcement qualifiers (~all, -all, ?all). No signup required.
+
 [Punycode Converter](https://alltoolsverse.com/tools/punycode-converter/) - Free browser tool for converting internationalized domain names between Unicode and ASCII Punycode in both directions. No signup required.
 
 [Domain Hunter](https://github.com/WhiteBite/Domain-Hunter) - Free, open-source, 100% client-side bulk domain availability checker: queries registry RDAP directly from the browser (no servers, no API keys, no tracking) across 148 TLD zones, with DNS-over-HTTPS corroboration for low-trust ccTLDs, IDN/punycode handling, live registrar prices and CSV/Markdown/TSV export. MIT. ([live demo](https://whitebite.github.io/Domain-Hunter/))


### PR DESCRIPTION
Adds Nutilz SPF Record Generator (https://nutilz.com/spf-record-generator), a free browser-based SPF TXT record builder and validator. Complements the existing SPF/DKIM/DMARC checker tools already listed (IntoDNS.ai, Relaymetry, DNSai, Valla DNS, admintoolkit.io) as well as our own prior DMARC Record Generator entry — this one is dedicated to building/validating SPF records specifically, including RFC 7208 10-lookup-limit counting and provider presets.

Disclosure: I am affiliated with nutilz.com.